### PR TITLE
Steps -> Ration

### DIFF
--- a/LLMs/Mistral-7b/Mistral_Colab_Finetune_ipynb_Colab_Final.ipynb
+++ b/LLMs/Mistral-7b/Mistral_Colab_Finetune_ipynb_Colab_Final.ipynb
@@ -1212,7 +1212,7 @@
         "#     args=transformers.TrainingArguments(\n",
         "#         per_device_train_batch_size=1,\n",
         "#         gradient_accumulation_steps=4,\n",
-        "#         warmup_steps=0.03,\n",
+        "#         warmup_ratio=0.03,\n",
         "#         max_steps=100,\n",
         "#         learning_rate=2e-4,\n",
         "#         fp16=True,\n",


### PR DESCRIPTION
## Bug Fix:
In _"Step 5 - Run the training!
"_, in _TrainingArguments_:
`warmup_steps` is an **int** value, I assume you wanted to set `warmup_ratio`.